### PR TITLE
Fix Double.parse not working because of Culture

### DIFF
--- a/ApcupsdLib/DictionaryExtensions.cs
+++ b/ApcupsdLib/DictionaryExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace ApcupsdLib
 {
@@ -22,7 +23,9 @@ namespace ApcupsdLib
 
         public static double? GetNullableDouble(this Dictionary<string, string> dict, string key)
         {
-            return dict.ContainsKey(key) ? (double?)Double.Parse(dict[key].Split(' ')[0]) : null;
+            // We need to use CultureInfo.InvariantCulture to force . to be used as the decimal separator.
+            // In other regions like europe the parse would fail since the value from apcupsd uses . but in europe we use ,
+            return dict.ContainsKey(key) ? (double?)Double.Parse(dict[key].Split(' ')[0],NumberStyles.Any, CultureInfo.InvariantCulture) : null;
         }
 
         public static int? GetNullableInt(this Dictionary<string, string> dict, string key)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Use the simple client in C# to query NIS:
     var upsEventsArray = client.GetEvents();
     
 To subscribe to events from the apcupsd.events file:
+
     var listener = new ApcupsdEventListener();
     listener.UpsEventReceived += (sender, args) =>
     {


### PR DESCRIPTION
Just tried to use your lib and it exploded.
Debugged it, and it was breaking at this Double.parse because in my country we use , (comma) for decimal separator not . (dot) but apcupsd seems to always use a . (dot)
Applied this fix, let me know what you think.

PS: Also added a newline in the readme the sample code wasn't formatted correctly