### PR TITLE
System.FormatException fix

### DIFF
--- a/ApcupsdLib/DictionaryExtensions.cs
+++ b/ApcupsdLib/DictionaryExtensions.cs
@@ -6,6 +6,8 @@ namespace ApcupsdLib
 {
     internal static class DictionaryExtensions
     {
+        private static readonly CultureInfo USCulture = new CultureInfo("en-US");
+
         public static string GetStringOrEmpty(this Dictionary<string, string> dict, string key)
         {
             return dict.ContainsKey(key) ? dict[key] : string.Empty;
@@ -13,7 +15,7 @@ namespace ApcupsdLib
 
         public static DateTime? GetNullableDateTime(this Dictionary<string, string> dict, string key)
         {
-            return dict.ContainsKey(key) && dict[key] != "N/A" ? (DateTime?)DateTime.Parse(dict[key]) : null;
+            return dict.ContainsKey(key) && dict[key] != "N/A" ? (DateTime?)DateTime.Parse(dict[key], DictionaryExtensions.USCulture) : null;
         }
 
         public static DateTime GetDateTime(this Dictionary<string, string> dict, string key)


### PR DESCRIPTION
Hello all,

I got an exception while parsing the status data. My system uses the "de-DE" date time format.

![image](https://user-images.githubusercontent.com/33397649/220883556-3cca1324-4871-4495-bcd9-7e1695cd362e.png)

My "apcaccess" output: 

APC      : 001,044,1039
DATE     : 2023-02-23 11:18:19 +0100  
HOSTNAME : ************************
VERSION  : 3.14.14 (31 May 2016) debian
UPSNAME  : USV02
CABLE    : Ethernet Link
DRIVER   : SNMP UPS Driver
UPSMODE  : Stand Alone
STARTTIME: 2023-02-23 11:17:18 +0100  
MODEL    : Smart-UPS 2200
STATUS   : ONLINE 
LINEV    : 227.0 Volts
LOADPCT  : 57.0 Percent
BCHARGE  : 100.0 Percent
TIMELEFT : 15.0 Minutes
MBATTCHG : 5 Percent
MINTIMEL : 3 Minutes
MAXTIME  : 30 Seconds
MAXLINEV : 228.0 Volts
MINLINEV : 227.0 Volts
OUTPUTV  : 227.0 Volts
SENSE    : High
DWAKE    : 0 Seconds
DSHUTD   : 0 Seconds
DLOWBATT : 2 Minutes
LOTRANS  : 208.0 Volts
HITRANS  : 253.0 Volts
ITEMP    : 19.0 C
ALARMDEL : 30 Seconds
BATTV    : 54.0 Volts
LINEFREQ : 50.0 Hz
LASTXFER : Automatic or explicit self test
NUMXFERS : 0
TONBATT  : 0 Seconds
CUMONBATT: 0 Seconds
XOFFBATT : N/A
SELFTEST : OK
STESTI   : OFF
STATFLAG : 0x05000008
MANDATE  : 01/17/2013
SERIALNO : ****************
BATTDATE : 11/15/2021
NOMOUTV  : 230 Volts
FIRMWARE : UPS 08.3 / MCU 14.0
END APC  : 2023-02-23 11:18:37 +0100

I just forced the parser to use the "en-US" culture. It works now as expected.